### PR TITLE
fix catalog to reader GET query, remove domain hardcoding

### DIFF
--- a/catalog/js/catalog.js
+++ b/catalog/js/catalog.js
@@ -19,7 +19,7 @@ function load() {
                             <p>Last update: ?</p>\
                             <p>\
                                 Link:\
-                                <a href="reader.html?id='+manga["id"]+'">reader</a>\
+                                <a href="reader.html?manga='+manga["id"]+'">reader</a>\
                             </p>\
                         </td>\
                     </tr>';
@@ -28,7 +28,7 @@ function load() {
             document.getElementById("titles").innerHTML = strCatalog;
         }
     }
-    xmlhttp.open("GET", "https://amangathing.ddns.net/db.json", true);
+    xmlhttp.open("GET", "/db.json", true);
     xmlhttp.send();
 }
 

--- a/reader/js/reader.js
+++ b/reader/js/reader.js
@@ -238,7 +238,7 @@ xmlhttp.onreadystatechange = function () {
         }
     }
 }
-xmlhttp.open("GET", "https://amangathing.ddns.net/db.json", true);
+xmlhttp.open("GET", "/db.json", true);
 xmlhttp.send();
 
 


### PR DESCRIPTION
catalog.js should be writing reader links using `manga` in the query string, not `id`

also remove fqdn from requests